### PR TITLE
Update setup.py to depend on latest Ray version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def get_cuda_version_str(no_dot=False):
 
 install_require_list = [
     "tqdm",
-    "ray==2.1.0",
+    "ray",
     "jax==0.3.22",
     "chex==0.1.5",
     "flax==0.6.2",


### PR DESCRIPTION
Alpa doesn't have to depend on a really old version of Ray.
Relax to depend on the latest version.